### PR TITLE
Fix cookie parameter name

### DIFF
--- a/src/swoole/Swoole/Http/Response.php
+++ b/src/swoole/Swoole/Http/Response.php
@@ -72,14 +72,14 @@ class Response
      * urlencoded when set.
      *
      * @alias This method has an alias of \Swoole\Http\Response::setCookie().
-     * @param Cookie|string $name The name of the cookie as a string, or a Cookie object.
+     * @param Cookie|string $name_or_object The name of the cookie as a string, or a Cookie object.
      *                            Only string values were accepted before Swoole 6.0.0.
      * @param bool $partitioned Specifies whether the cookie should be stored using partitioned storage.
      *                          Available since Swoole 6.0.0; prior versions did not support partitioned storage for cookies.
      * @see \Swoole\Http\Response::setCookie()
      * @see \Swoole\Http\Response::rawcookie()
      */
-    public function cookie(Cookie|string $name, string $value = '', int $expires = 0, string $path = '/', string $domain = '', bool $secure = false, bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool
+    public function cookie(Cookie|string $name_or_object, string $value = '', int $expires = 0, string $path = '/', string $domain = '', bool $secure = false, bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool
     {
     }
 
@@ -87,14 +87,14 @@ class Response
      * Set a cookie.
      *
      * @alias Alias of method \Swoole\Http\Response::cookie().
-     * @param Cookie|string $name The name of the cookie as a string, or a Cookie object.
+     * @param Cookie|string $name_or_object The name of the cookie as a string, or a Cookie object.
      *                            Only string values were accepted before Swoole 6.0.0.
      * @param bool $partitioned Specifies whether the cookie should be stored using partitioned storage.
      *                          Available since Swoole 6.0.0; prior versions did not support partitioned storage for cookies.
      * @see \Swoole\Http\Response::cookie()
      * @since 4.4.0
      */
-    public function setCookie(Cookie|string $name, string $value = '', int $expires = 0, string $path = '/', string $domain = '', bool $secure = false, bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool
+    public function setCookie(Cookie|string $name_or_object, string $value = '', int $expires = 0, string $path = '/', string $domain = '', bool $secure = false, bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool
     {
     }
 


### PR DESCRIPTION
Parameter name changed here: https://github.com/swoole/swoole-src/pull/5420/files#diff-e89c22bc166151ba4aa4b15babdbc6f4beab7e67bc99485d4be9e023a78b1956

But was not updated in the IDE helper. Using named parameters leads to an unlisted breaking change for v6: "Unknown named parameter $name"